### PR TITLE
fix: resolve no executable found for `awviz`

### DIFF
--- a/awviz/CMakeLists.txt
+++ b/awviz/CMakeLists.txt
@@ -25,6 +25,15 @@ ament_auto_find_build_dependencies()
 add_executable(${PROJECT_NAME} src/main.cpp)
 target_link_libraries(${PROJECT_NAME} awviz_common::awviz_common)
 
+# -------- install executable --------
+install(TARGETS ${PROJECT_NAME}
+  DESTINATION bin
+)
+
+install(TARGETS ${PROJECT_NAME}
+  DESTINATION lib/${PROJECT_NAME}
+)
+
 # -------- for testing --------
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)


### PR DESCRIPTION
## Description

Fix `CMakeLists.txt` to allow to use both `ros2 run awviz awviz` and `awviz` command

## How was this PR tested?

```bash
colcon build --symlink-install
source install/setup.bash

# use ros2 command
ros2 run awviz awviz

# use awviz command directly
awviz
```

## Notes for reviewers

None.

## Effects on system behavior

None.
