### PR TITLE
chore(deps): remove `autoware.repos`

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -40,5 +40,4 @@ jobs:
         with:
           package-name: ${{ steps.list_packages.outputs.packages }}
           target-ros2-distro: ${{ matrix.rosdistro }}
-          vcs-repo-file-url: autoware.repos
           import-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -56,9 +56,6 @@ COLCON_IGNORE
 # VSCode
 .vscode
 
-# Clang
-compile_flags.txt
-
 .cache
 html
 latex

--- a/README.md
+++ b/README.md
@@ -15,9 +15,10 @@ AWViz-ROS features a ROS viewer for [Autoware](https://autoware.org) powered by 
 git clone git@github.com:ktro2828/awviz-ros && cd awviz-ros
 
 # import external dependencies
-mkdir src && vcs import src < autoware.repos
+rosdep update
+rosdep install -y --from-paths . --ignore-src --rosdistro $ROS_DISTRO
 
-# build awviz
+# build awviz packages
 colon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release
 source install/setup.bash
 ```

--- a/autoware.repos
+++ b/autoware.repos
@@ -1,5 +1,0 @@
-repositories:
-  autoware_msgs:
-    type: git
-    url: https://github.com/autowarefoundation/autoware_msgs.git
-    version: main

--- a/awviz/CMakeLists.txt
+++ b/awviz/CMakeLists.txt
@@ -19,11 +19,12 @@ endif()
 
 # -------- find dependencies --------
 find_package(ament_cmake_auto REQUIRED)
+find_package(rerun_sdk REQUIRED)
 ament_auto_find_build_dependencies()
 
 # -------- add executable --------
 add_executable(${PROJECT_NAME} src/main.cpp)
-target_link_libraries(${PROJECT_NAME} awviz_common::awviz_common)
+target_link_libraries(${PROJECT_NAME} awviz_common::awviz_common rerun_sdk)
 
 # -------- install executable --------
 install(TARGETS ${PROJECT_NAME}

--- a/awviz/package.xml
+++ b/awviz/package.xml
@@ -11,7 +11,6 @@
 
   <depend>rclcpp</depend>
   <depend>awviz_common</depend>
-  <depend>rerun_sdk</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/awviz_plugin/CMakeLists.txt
+++ b/awviz_plugin/CMakeLists.txt
@@ -19,6 +19,7 @@ endif()
 
 # -------- find dependencies --------
 find_package(ament_cmake_auto REQUIRED)
+find_package(rerun_sdk REQUIRED)
 ament_auto_find_build_dependencies()
 
 # -------- link targets --------

--- a/awviz_plugin/package.xml
+++ b/awviz_plugin/package.xml
@@ -12,8 +12,8 @@
   <depend>awviz_common</depend>
   <depend>cv_bridge</depend>
   <depend>pluginlib</depend>
-  <depend>rerun_sdk</depend>
   <depend>sensor_msgs</depend>
+  <depend>rclcpp</depend>
   <depend>autoware_perception_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>


### PR DESCRIPTION
## Description

Related to https://github.com/ktro2828/awviz-ros/issues/49.

Remove `autoware.repos` and allow to install without using `vcs import`.
Instead of previous processes, we can install external packages with `rosdep`.

## How was this PR tested?

I confirmed build successfully with following steps:

```shell
rosdep update
rosdep install -y --from-paths . --ignore-src --rosdistro $ROS_DISTRO

colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release
```

## Notes for reviewers

None.

## Effects on system behavior

None.
