### PR TITLE
chore(deps): bump `rerun-sdk` to `v0.19.0`

### DIFF
--- a/awviz_common/CMakeLists.txt
+++ b/awviz_common/CMakeLists.txt
@@ -23,7 +23,7 @@ ament_auto_find_build_dependencies()
 
 # -------- fetch contents --------
 include(FetchContent)
-FetchContent_Declare(rerun_sdk URL https://github.com/rerun-io/rerun/releases/download/0.18.0/rerun_cpp_sdk.zip)
+FetchContent_Declare(rerun_sdk URL https://github.com/rerun-io/rerun/releases/download/0.19.0/rerun_cpp_sdk.zip)
 FetchContent_MakeAvailable(rerun_sdk)
 # Ensure rerun_sdk is compiled with -fPIC
 set_target_properties(rerun_sdk PROPERTIES POSITION_INDEPENDENT_CODE ON)


### PR DESCRIPTION
## Description

As of the last week, `rerun-sdk==v0.19.0` has been released.
This PR bump the version of rerun to `v0.19.0`.

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
