### PR TITLE
chore(deps): dump rerun-sdk to v0.20.0

### DIFF
--- a/awviz_common/CMakeLists.txt
+++ b/awviz_common/CMakeLists.txt
@@ -23,7 +23,7 @@ ament_auto_find_build_dependencies()
 
 # -------- fetch contents --------
 include(FetchContent)
-FetchContent_Declare(rerun_sdk URL https://github.com/rerun-io/rerun/releases/download/0.19.0/rerun_cpp_sdk.zip)
+FetchContent_Declare(rerun_sdk URL https://github.com/rerun-io/rerun/releases/download/0.20.0/rerun_cpp_sdk.zip)
 FetchContent_MakeAvailable(rerun_sdk)
 # Ensure rerun_sdk is compiled with -fPIC
 set_target_properties(rerun_sdk PROPERTIES POSITION_INDEPENDENT_CODE ON)


### PR DESCRIPTION
## Description

`rerun-sdk==v0.20.0` has been released, this PR bump `rerun-sdk` to `v0.20.0`.

## How was this PR tested?

I confirmed build was succeeded.

## Notes for reviewers

None.

## Effects on system behavior

None.
